### PR TITLE
Update Price and Product Classes per API Documentation

### DIFF
--- a/PAYNLSDK.SDK/V2/DataTransferModels/Transaction/Price.cs
+++ b/PAYNLSDK.SDK/V2/DataTransferModels/Transaction/Price.cs
@@ -4,12 +4,6 @@ namespace PayNlSdk.Sdk.V2.DataTransferModels.Transaction;
 
 public class Price
 {
-    [JsonPropertyName("value")]
-    public int? Value { get; set; }
-
-    [JsonPropertyName("quantity")]
-    public decimal? Quantity { get; set; }
-
-    [JsonPropertyName("vatCode")]
-    public string? VatCode { get; set; }
+	[JsonPropertyName("value")]
+	public int? Value { get; set; }
 }

--- a/PAYNLSDK.SDK/V2/DataTransferModels/Transaction/Product.cs
+++ b/PAYNLSDK.SDK/V2/DataTransferModels/Transaction/Product.cs
@@ -4,15 +4,21 @@ namespace PayNlSdk.Sdk.V2.DataTransferModels.Transaction;
 
 public class Product
 {
-    [JsonPropertyName("value")]
-    public string? Id { get; set; }
+	[JsonPropertyName("id")]
+	public string? Id { get; set; }
 
-    [JsonPropertyName("description")]
-    public string? Description { get; set; }
+	[JsonPropertyName("description")]
+	public string? Description { get; set; }
 
-    [JsonPropertyName("type")]
-    public string? Type { get; set; }
+	[JsonPropertyName("type")]
+	public string? Type { get; set; }
 
-    [JsonPropertyName("price")]
-    public Price? Price { get; set; }
+	[JsonPropertyName("price")]
+	public Price? Price { get; set; }
+
+	[JsonPropertyName("quantity")]
+	public decimal? Quantity { get; set; }
+
+	[JsonPropertyName("vatCode")]
+	public string? VatCode { get; set; }
 }


### PR DESCRIPTION
This pull request modifies the `Price` and `Product` classes to align with the API documentation. The changes simplify the `Price` class structure and relocate specific properties to the `Product` class for alignment with the API schema.

## Changes Made
- **Price Class**:
  - Removed `Quantity` and `VatCode` properties, as they are no part of the `Price` object per the API documentation.
  - Retained `Value` property with no changes to its structure.

- **Product Class**:
  - Renamed the `value` property to `id` to match the API's naming convention.
  - Added `Quantity` and `VatCode` properties, relocated from the `Price` class, to align with the API schema.
  - No changes to `Description`, `Type`, or `Price` properties.

## Purpose
These updates ensure that the `Price` and `Product` classes conform to the API specifications, improving data consistency and compatibility with external services.

## Additional Notes
Please review the changes to ensure they align with the expected behavior. Refer to the API documentation for detailed specifications.